### PR TITLE
Added scripts/hostname.bash to set a unique hostname at boot

### DIFF
--- a/docs/roboquest_update.txt
+++ b/docs/roboquest_update.txt
@@ -151,6 +151,9 @@ camera_auto_detect=1
            sudo netplan --debug generate
            sudo netplan apply
 
+    - set unique hostname
+        cp scripts/roboquest-hostname.service /etc/systemd/system/
+
     - define Access Point nmcli connection
         cp scripts/roboquest-network.service /etc/systemd/system/
 
@@ -161,14 +164,13 @@ camera_auto_detect=1
         cp scripts/roboquest.service /etc/systemd/system/
 
         chmod 0664 /etc/systemd/system/roboquest*service
+	systemctl enable roboquest-hostname.service
 	systemctl enable roboquest-network.service
 	systemctl enable roboquest-shutdown.service
 	systemctl enable roboquest.service
         systemctl daemon-reload
 
-
     - update RobotConsole Config Settings
-
 
 
 8. Run it

--- a/scripts/hostname.bash
+++ b/scripts/hostname.bash
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Bill Mania, 12 Feb 2022
+#
+# Executed at boot to ensure the hostname is unique,
+# before requesting an IP address from the DHCP service.
+#
+
+HOSTNAME_BASE="rq"
+
+#
+# In order to create a unique hostname, append
+# the last 5 digits of the machine ID.
+#
+UNIQUE_HOST=$(grep -o '.....$' /etc/machine-id)
+HOSTNAME="$HOSTNAME_BASE-$UNIQUE_HOST"
+
+hostnamectl set-hostname "$HOSTNAME"
+hostnamectl set-chassis embedded
+hostnamectl set-deployment development
+hostnamectl set-location mobile
+
+logger -p user.notice  "Hostname set to $HOSTNAME"
+
+exit 0

--- a/scripts/hostname.bash
+++ b/scripts/hostname.bash
@@ -10,9 +10,12 @@ HOSTNAME_BASE="rq"
 
 #
 # In order to create a unique hostname, append
-# the last 5 digits of the machine ID.
+# the last 4 digits of the eth0 MAC address.
 #
-UNIQUE_HOST=$(grep -o '.....$' /etc/machine-id)
+UNIQUE_HOST=$(ip address show dev eth0 scope link | \
+	       awk '/ether/{print $2}' | \
+	       sed 's/://g' | \
+	       grep -o '....$')
 HOSTNAME="$HOSTNAME_BASE-$UNIQUE_HOST"
 
 hostnamectl set-hostname "$HOSTNAME"

--- a/scripts/roboquest-hostname.service
+++ b/scripts/roboquest-hostname.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Setup the RoboQuest hostname
+Wants=basic.target
+
+[Service]
+ExecStart=/home/ubuntu/catkin_ws/src/roboquest_core/scripts/hostname.bash
+Restart=no
+Type=oneshot
+
+[Install]
+WantedBy=network-pre.target


### PR DESCRIPTION
Created the script hostname.bash, to set a unique hostname for each RaspPi at boot, based on part of the unique Machine ID.
Updated docs/roboquest_update.txt with instructions on how to install this script as a systemd service.