### PR TITLE
Updated roboquest_core.launch

### DIFF
--- a/launch/roboquest_core.launch
+++ b/launch/roboquest_core.launch
@@ -1,12 +1,12 @@
 <launch>
   <env name="ROSCONSOLE_CONFIG_FILE"
-       value="$(find roboquest_core)/launch/rosconsole_config"/>
+       value="$(find roboquest_ui)/src/RobotConsole/rosconsole_config"/>
 
   <env name="ROSCONSOLE_FORMAT"
        value="${time} ${severity} ${node}-${function}: ${message}"/>
 
   <env name="ROS_PYTHON_LOG_CONFIG_FILE"
-       value="$(find roboquest_core)/launch/rospython_config"/>
+       value="$(find roboquest_ui)/src/RobotConsole/rospython_config"/>
 
   <node
     name="servo_controller"


### PR DESCRIPTION
Now uses the ROS log configuration files from RobotConsole, to avoid duplicating the config files.
Config files were updated to eliminate ROS DEBUG entries and rotate the files at one megabyte.