### PR TITLE
Updated the procedure in roboquest_update.txt

### DIFF
--- a/docs/roboquest_update.txt
+++ b/docs/roboquest_update.txt
@@ -25,6 +25,9 @@ https://raspberrytips.com/create-image-sd-card/
         sudo hostnamectl set-hostname pi-focal
         sudo timedatectl set-timezone America/Los_Angeles
     - add hosts to /etc/hosts for ROS
+    - update /etc/logrotate.d/rsyslog
+	- replace all timeframes from [weekly, monthly] to daily
+	- set all rotate to 2
 
 2. add OS packages and configure hardware
     sudo apt install python3-smbus python3-rpi.gpio


### PR DESCRIPTION
roboquest_update.txt is the procedure for building a new RoboQuest OS image. Since the syslog configuration file isn't part of any repository, this update will require some manual intervention and the creation of a new RoboQuest OS image for the Raspberry Pi.
It requires four edits to a single file, /etc/logrotate.d/rsyslog and then a restart.

The same configuration change can be made on an existing RoboQuest machine. 